### PR TITLE
Add Schema Support for PostgreSQL Tables

### DIFF
--- a/src/test/suite/engines/postgres.test.ts
+++ b/src/test/suite/engines/postgres.test.ts
@@ -193,7 +193,7 @@ describe('PostgreSQL Tests', () => {
 				.replace(/\s+/g, ' ')
 				.trim();
 
-			assert.strictEqual(creationSql, 'CREATE TABLE users ( id integer, name CHARACTER varying (255), age integer, location CHARACTER varying (255) );');
+			assert.strictEqual(creationSql, 'CREATE TABLE public.users ( id integer, name CHARACTER varying (255), age integer, location CHARACTER varying (255) );');
 		});
 
 		it('should filter values in uuid and integer column types', async () => {


### PR DESCRIPTION
## Changes
- Added support for handling table schemas in PostgreSQL operations
- Modified table name handling to include schema information
- Updated SQL queries to properly reference schema-qualified tables
- Added helper functions to parse and format table names with schemas

## Technical Details
- Added `getTableSchema` and `getTableName` utility functions to handle schema.table format
- Updated table creation SQL to include schema name in the generated CREATE TABLE statement
- Modified table listing to include schema information
- Updated column and foreign key queries to respect table schemas
- Fixed test cases to account for schema-qualified table names

## Impact
This change improves PostgreSQL support by properly handling tables in different schemas, not just the default 'public' schema. All database operations now correctly reference tables with their schema names.

## Testing
- Updated existing test cases to verify schema handling
- Verified table creation with schema-qualified names